### PR TITLE
Stats Bonuses overhaul and Movement overhaul

### DIFF
--- a/.obsidian/community-plugins.json
+++ b/.obsidian/community-plugins.json
@@ -3,5 +3,6 @@
   "obsidian-languagetool-plugin",
   "obsidian-sort-and-permute-lines",
   "table-editor-obsidian",
-  "find-unlinked-files"
+  "find-unlinked-files",
+  "editing-toolbar"
 ]

--- a/Game/Agility.md
+++ b/Game/Agility.md
@@ -7,7 +7,7 @@ grand_parent: How To Play
 ---
 ## Agility
 
-Measures how agile your character is. Influences movement speed #TODOMovement. 
+Measures how agile your character is. Influences [Movement Distance](Stats#Movement%20Distance). 
 
 It can be honed to better perform the [Skills](Skills):
 ### Accuracy

--- a/Game/Attack-Bonuses.md
+++ b/Game/Attack-Bonuses.md
@@ -7,8 +7,6 @@ grand_parent: Telling The Story
 ---
 ## Attack Bonuses
 These are common bonuses and negatives you can receive on your attacks which will make attacking easier. This is not an exhaustive list and sometimes, if you feel you are advantaged over your opponent, you should express this to your GM, and they may give you additional bonuses. As well, some combat bonuses can be learned by taking specific combat training, or having specific pieces of equipment.
-### Charging
-When making a melee attack or manoeuvre, if you have moved at least 3 meters towards your opponent you get a +1 to the skill test.
 ### Shooting Position
 If when shooting you are in a comfortable position you get a +1 to the skill test.
 ### Outnumbered
@@ -20,10 +18,10 @@ When making an attack or manoeuvre, if your opponent is unaware of your presence
 ### On The Move
 If you have moved this turn, you take a -2 to attacks and manoeuvres.
 ### Unweighted for Throwing
-If you attempt to throw a weapon that doesn’t have the thrown tag you receive a -3 on the skill test. Basic weapons only have a -1 penalty.
+If you attempt to throw a weapon that doesn’t have the thrown tag, you receive a -3 on the skill test. Basic weapons only have a -1 penalty.
 ### On Your Back
 When attempting a melee test, if you are prone, you receive a -2.
 ### Distance Penalty
-When you fire a ranged weapon if you are outside the range, you suffer a -1 per range they are away from you.
+When you fire a ranged weapon if you are outside the range, you suffer similar negatives to [Movement Action Penalty](Movement#Movement%20Action%20Penalty).
 
 > So if you have a range of 10m and are attacking 35 meters away, you suffer a -3.

--- a/Game/Attacks.md
+++ b/Game/Attacks.md
@@ -14,9 +14,11 @@ Usually, in combat, you will be trying to harm your opponents with the goal of k
 * Magic attacks using [Will](Spirit#Will)
 
 ### Attack Range
-When you attack something, your range is how far you can engage them from. With melee weapons, you need to be within 2m. With Range, Thrown, and Magic you have a range, but it is possible to attack up to 5x your range, but you will suffer [Distance Penalty](#Distance%20Penalty). #TODOMovement 
-* Magic attacks have a range of 10m
-* Thrown have a range of 3 times your [Strength](Strength)
+When you attack something, your range is how far you can engage them from. 
+* If a weapon doesn't specify a range it is assumed you need to be within [Reach](Movement#Reach).
+* If you aren't within a weapons range you can either [Move](Combat-Turn#Move), or suffer a [Distance Penalty](Attack-Bonuses#Distance%20Penalty), or perhaps, both.
+* Magic generally has a range of [Close](Movement#Close).
+* Items can be thrown [Close](Movement#Close).
 * Ranged attacks will be defined in the weapons [traits](Weapons#[Weapon-Traits](Weapon-Traits)).
 
 ### Attacking

--- a/Game/Brawler.md
+++ b/Game/Brawler.md
@@ -20,7 +20,7 @@ They can generally teach the following training:
 ### Basic
 
 #### Black Belt
-When not holding anything can perform a [Melee Attack](Terminology#Melee%20Attack) as though you had a melee weapon with a damage bonus of $2 \times Strength$ 
+Your [Unarmed Attack](Terminology#Unarmed%20Attack), have a [Damage Bonus](Weapons#Damage%20Bonus) of $2 \times Strength$. 
 
 #### Bushwhacker
 Whenever someone performs a [Mitigated Attack](Terminology#Mitigated%20Attack) against you in melee, you may spend a [Reaction](Terminology#Reaction) to make an [Attack](Terminology#Attack) with a hit location of the limb they attacked with.
@@ -57,7 +57,7 @@ After suffering an [Injury](Injury) that would make you [Wounded](Injury#Wounded
 If you cause an [Injuring Attack](Terminology#Injuring%20Attack) on a [Character](Terminology#Character) you are [In Melee](Terminology#In%20Melee) with that causes a [Critical Injury](Injury#Critical%20Injury) or more severe, you may make an additional [Attack](Terminology#Attack) against another enemy with the same weapon and [Combat Modifiers](Attacks#Combat%20Modifiers).
 
 #### Clothesline
-If an opponent is [Charging](Attack-Bonuses#Charging) #TODOMovement you, you may spend a [Reaction](Terminology#Reaction) to make a [Strike](Strength#Strike) [Opposed Difficulty](Skills#Opposed%20Difficulty)([Strike](Strength#Strike)+2), that if successful causes their attack to fail and knocks them prone.
+If an [Opponent](Terminology#Opponent) moves within [Reach](Movement#Reach) of you, you may spend a [Reaction](Terminology#Reaction) to make a [Strike](Strength#Strike) [Opposed Difficulty](Skills#Opposed%20Difficulty)([Strike](Strength#Strike)+2), that if successful causes their attack to fail and knocks them prone.
 
 > So the skill test would be at a (-4) penalty against someone with 2 ranks in [Strike](Strength#Strike)
 
@@ -90,7 +90,7 @@ Your [Charging](Attack-Bonuses#Charging) attacks have the [Penetrating](Weapon-T
 When in a [Grapple](Special-Combat-Actions#grapple) with an opponent, and you opt to inflict an injury, it is a [Critical Injury](Injury#Critical%20Injury).
 
 #### Rip and Tear
-Your [Attacks](Terminology#Attack) while unarmed get the [Penetrating](Weapon-Traits#Penetrating) quality, and +2 damage bonus.
+Your [Unarmed Attack](Terminology#Unarmed%20Attack) get the [Penetrating](Weapon-Traits#Penetrating) quality, and +2 damage bonus.
 
 #### Shake it off
 Whenever a negative [Effect](Effects) happens to you, roll 1d6 on a roll of 4-6 you ignore the effect.

--- a/Game/Character-Development.md
+++ b/Game/Character-Development.md
@@ -15,7 +15,7 @@ As your characters gain [Total XP](Stats#Total%20XP) you gain additional benefit
 | [Total XP](Stats#Total%20XP) | Reward                                                                                                           |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | 10                           | Increase a [Skill](Skills) by 1 rank (but not to rank 3)                                                         |
-| 15                           | Increase your [Power](Stats#Power), [Max Toxicity](Stats#Max%20Toxicity), or [Initiative](Stats#Initiative) by 1 |
+| 15                           | Increase your [Power](Stats#Power), [Max Toxicity](Stats#Affinity), or [Initiative](Stats#Initiative) by 1 |
 | 20                           | Increase a [Skill](Skills) by 1 rank                                                                             |
 | 25                           | Increase an [Attribute](Stats#Attributes) by 1                                                                   | 
 | 30                           | Increase a [Skill](Skills) by 1 rank                                                                             |
@@ -85,7 +85,7 @@ Transhumanist processes come in a few variations. 
 Characters in Aspirant may suffer from debilitating injury. To combat this, prosthetics may be installed. Simple prosthetics do not count as transhumanist effects.
 
 #### Toxicity
-Each transhumanist affect your character has reduces your [max toxicity](Stats#Max%20Toxicity) by 1. 
+Each transhumanist affect your character has reduces your [max toxicity](Stats#Affinity) by 1. 
 
 #### Acquiring Transhumanist Effects
 * Purchased: [Buying](#Buying)

--- a/Game/Combat-Turn.md
+++ b/Game/Combat-Turn.md
@@ -8,9 +8,16 @@ grand_parent: Telling The Story
 
 ## Combat Turn
 In combat, a turn is a [Character's](#Character) portion of the round. What they are doing is happening in parallel with everyone else, but for simplicity the game takes things in an order determined by [Initiative Value](Combat#Initiative%20Value). On Your turn in combat, you can do basically anything that can feasibly be done in 5 seconds. You are encouraged to get creative and talk to the GM; however, several common scenarios are provided to use as an example. The simple way to think about it though is on your turn, you can either:
-- Do an Action (usually involves a skill test).
-- Move up to 2 * [Agility](Agility) meters #TODOMovement, then do an action with all skill tests at (-2).
+- Do an [Action](Terminology#Action).
+- [Move](#Move)
 - [Delay](#Delay).
+
+### Move
+In combat, you can either move to get to an [Opponent](Terminology#Opponent) to perform an [Action](Terminology#Action), or to reposition to a different strategic location.
+
+If you are moving towards an enemy, you will suffer a penalty to any [Action](Terminology#Action)
+
+
 
 ### Delay
 When you delay your combat turn, you can instead choose to act after any other character has finished their combat turn. You need to use your delayed action before your next combat turn (this can lead to you taking back to back turns).

--- a/Game/Communication.md
+++ b/Game/Communication.md
@@ -7,7 +7,7 @@ grand_parent: How To Play
 ---
 ## Communication
 
-Measures how well you communicate. Influences the number of people who will follow you.
+Measures how well you communicate. Influences your max [Influence](Stats#Influence).
 
 It can be honed to better perform the [Skills](Skills):
 ### Confidence

--- a/Game/Designing-Storage.md
+++ b/Game/Designing-Storage.md
@@ -10,7 +10,7 @@ nav_order: 2
 ### Crafting Storage
 Efficient storage requires numerous small latches and fixings and meticulous tailored pieces to come together into a functional piece. General costs for crafting different pieces of storage are as follows:
 * Belts: Base cost of 10 silver for 4 units of storage.
-* Bags: Base cost of 5 silver for 6 units of storage.
+* Bags: Base cost of 5 silver for 4 + [Strength](Strength) units of storage.
 * Saddlebags: Base cost of 10 silver for 10 units of storage
 
 Every type of storage can have up to 4 additional size.

--- a/Game/Designing-Weapons.md
+++ b/Game/Designing-Weapons.md
@@ -9,10 +9,11 @@ nav_order: 2
 Through play and when creating a character, you may be asked to select a weapon. You can use one of the [Example-Weapons](Example-Weapons) or design your own. Perhaps your character hales from a distant land which uses a unique weapon, or a blacksmith has an idea for a specialized weapon for your character's fighting style. 
 
 To build a weapon:
-- Choose the [Quality](#Quality)
-- Choose a [Size](Weapons#Size)
-- Select a [Damage Type](Weapons#Damage%20Type)
-- Select a number of [Weapon Traits](Weapon-Traits) for the weapon equal to the amount available based on [Quality](#Quality)
+- Choose the [Quality](#Quality).
+- Choose a [Size](Weapons#Size).
+- Select a [Damage Type](Weapons#Damage%20Type).
+- Include the [[]]
+- Select a number of [Weapon Traits](Weapon-Traits) for the weapon equal to the amount available based on [Quality](#Quality).
 
 ### Quality
 Weapons come in a variety of qualities based on the skill required to craft.
@@ -41,11 +42,16 @@ Generally, weapons material isn’t particularly important. Cheap materials will
 
 One benefit to exotic materials, however, is their potential for harming monsters. A sword made of silver might be known to harm werewolves, a spear made from elven wood is effective against wraiths, etc. In some exceptional cases, a material may provide a trait for free, increase damage bonus, or provide some skill bonus. 
 
+### Default Traits
+By default, all weapons have:
+* [Strength](Weapon-Traits#Strength).
+* [Size Matters](Weapon-Traits#Size%20Matters).
+
 ### Calculating Damage Bonus
 A weapons damage bonus is equal to:
-$size \times 2 + traits + quality$
+$traits + quality$
 
-> A [Size](Weapons#Size) 3 [Artisan](#Artisan) weapon, with the [Lethal](Weapon-Traits#Lethal) [Weapon Trait](Weapon-Traits) would have a damage bonus of 8, 6 from size, 1 from [Artisan](#Artisan), 1 from [Lethal](Weapon-Traits#Lethal).
+> A [Size](Weapons#Size) 3 [Artisan](#Artisan) weapon, with the [Lethal](Weapon-Traits#Lethal) [Weapon Trait](Weapon-Traits) would have a damage bonus of 8, 6 from [Size Matters](Weapon-Traits#Size%20Matters), 1 from [Artisan](#Artisan), 1 from [Lethal](Weapon-Traits#Lethal).
 
 ### Crafting
 A character looking to craft a specific weapon first requires 2x the size worth of materials and [Craftsman](Craftsman) training saying they are able to make what they want. 

--- a/Game/Dynamist.md
+++ b/Game/Dynamist.md
@@ -34,7 +34,7 @@ Your character can perform [Channelled Magic](Magic#Channelled%20Magic) to:
 Anyone targeted by your [Channelled Magic](Magic#Channelled%20Magic) [Ranged Attack](Terminology#Ranged%20Attack) suffers a (-1) to all [Actions](Terminology#Action) until your next [Combat Turn](Terminology#Combat%20Turn).
 
 #### Magical Dulling
-All magical abilities used near you #TODOMovement , including your own, are at a -1.
+All magical abilities used [Close](Movement#Close) to you, including your own, are at a -1.
 
 #### Magic Perception
 You can detect magic without needing to look for it with [Insight](Intelligence#Insight).
@@ -52,7 +52,7 @@ You may use any [Artisan](Materials#Artisan) or greater [Quality](Weapons#Qualit
 
 #### Counter Spell
 *[Requirement](Terminology#Requirement): [Amateur Dynamancy](#Amateur%20Dynamancy)*
-If another [Character](Terminology#Character) you can see, and within #TODOMovement casts a spell, you may spend a [Reaction](Terminology#Reaction) to disrupt the spell assuming you have the appropriate training. The [Channelled Magic](Magic#Channelled%20Magic) action is at a (-2).
+If another [Character](Terminology#Character) you can see, casts a spell, you may spend a [Reaction](Terminology#Reaction) to disrupt the spell assuming you have the appropriate training. The [Channelled Magic](Magic#Channelled%20Magic) action is at a (-2). This action has a range of [Close](Movement#Close), but can suffer a [Distance Penalty](Attack-Bonuses#Distance%20Penalty).
 
 #### Elemental Strike
 You may have weapons you [Attack](Terminology#Attack) with have the [Hot](Injury#Hot) or [Cold](Injury#Cold) [Types of Damage](Injury#Types%20of%20Damage).

--- a/Game/Effects.md
+++ b/Game/Effects.md
@@ -30,3 +30,6 @@ To stop being prone in combat you perform a [Grace](Agility#Grace) [Fixed Diffic
 * If you succeed you may stand as a [Free Action](Terminology#Free%20Action)
 * If you fail you may stand as a [Free Action](Terminology#Free%20Action) but cannot move during this [Combat Round](Terminology#Combat%20Round)
 
+### Slowed
+A slowed character can only move up to [Close](Movement#Close) on their next turn.
+

--- a/Game/Example-Storage.md
+++ b/Game/Example-Storage.md
@@ -6,18 +6,101 @@ grand_parent: Equipment
 nav_order: 2
 ---
 ## Example [Storage](Storage)
+{: .no_toc }
 * Non-exhaustive list of storage a character could use. You can instead design your own [Designing-Storage](Designing-Storage). 
-* Cost is the full charge to commission, including labour.
+* Commission is the full charge to commission, including labour.
 * Sell is the cost for just the materials, so what it's worth if it was sold in a shop.
 
-|Name|Type|Cost|Sell|Description|
-|---|---|---|---|---|
-|Adventure Bag|[Backpack](Storage#Backpack)|20|15|A practical and large bag, allowing the storage of 8 size of items.|
-|Alchemist Bag|[Backpack](Storage#Backpack)|45|15|A large backpack with a structured frame allowing you to separate and store different creature bits. Carries 3 size and up to 10 size worth of [Materials](Materials).|
-|Back Scabbard|[Backpack](Storage#Backpack)|20|5|A large, very functional sheath and balanced bag. Allows storing 4 size of items and a [weapon](Weapons) up to size 4.|
-|Hunters Saddle|[Saddlebag](Storage#Saddlebag)|20|10|You can carry 9 size worth of items and additionally 2 size worth of [Materials](Materials).|
-|Quiver|[Belt](Storage#Belt)|20|10|You can carry up to 2 size of [Munitions](Comestibles#Munitions) and 3 additional size worth of items.|
-|Utility Vest|[Belt](Storage#Belt)|25|20|A collection of pouches and loops allowing the storage of 6 size of items.|
-|Basic Belt|[Belt](Storage#Belt)|15|10|A simple belt allowing you to carry 4 size of items.|
-|Basic Bag|[Backpack](Storage#Backpack)|10|5|A simple bag allowing you to carry 6 size of items.|
-|Basic Saddlebags|[Saddlebag](Storage#Saddlebag)|15|10|Simple saddlebags allowing you to carry 10 size of items.|
+### Contents
+{: .no_toc }
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+
+### Adventure Bag
+*A practical and large bag.*
+* [Backpack](Storage#Backpack).
+* Commission 20 Silver.
+* Sells for 15 Silver.
+* Holds 6 + [Strength](Strength) size.
+
+---
+
+### Alchemist Bag
+*A large backpack with a structured frame allowing you to separate and store different creature bits.*
+* [Backpack](Storage#Backpack).
+* Commission 45 Silver.
+* Sells for 15 Silver.
+* Holds 1 + [Strength](Strength) size.
+* Holds an additional 10 size of [Materials](Materials).
+
+---
+
+### Back Scabbard
+*A large, very functional sheath and balanced bag.*
+* [Backpack](Storage#Backpack).
+* Commission 20 Silver.
+* Sells for 5 Silver.
+* Holds 2 + [Strength](Strength) size.
+* Holds an additional 4 size of [Weapons](Weapons).
+
+---
+
+### Basic Bag
+*A simple bag capable of holding some gear and loot.*
+* [Backpack](Storage#Backpack).
+* Commission 10 Silver.
+* Sells for 5 Silver.
+* Holds 4 + [Strength](Strength) size.
+
+---
+
+### Basic Belt
+*A simple belt with some space to attach or hang pouches and items.*
+* [Belt](Storage#Belt).
+* Commission 15 Silver.
+* Sells for 10 Silver.
+* Holds 4 size.
+
+---
+
+### Basic Saddlebags
+*A simple set of saddlebags, great for carrying and attaching gear long term.*
+* [Saddlebag](Storage#Saddlebag).
+* Commission 15 Silver.
+* Sells for 10 Silver.
+* Holds 10 size.
+### Quiver
+*A belt with a specialized quiver for ammunition.*
+* [Belt](Storage#Belt).
+* Commission 20 Silver.
+* Sells for 10 Silver.
+* Holds 3 size.
+* Holds an additional 2 size of [Munitions](Comestibles#Munitions).
+
+---
+
+### Scavengers Saddle
+*A large saddle pack, with specialized storage for scavenged materials.*
+* [Saddlebag](Storage#Saddlebag).
+* Commission 20 Silver.
+* Sells for 10 Silver.
+* Holds 9 size.
+* Holds an additional 2 size of [Materials](Materials).
+
+---
+
+### Utility Vest
+*A collection of pouches and loops distributed across the chest.*
+* [Belt](Storage#Belt).
+* Commission 25 Silver.
+* Sells for 20 Silver.
+* Holds 6 size.
+
+---

--- a/Game/Knight.md
+++ b/Game/Knight.md
@@ -54,9 +54,6 @@ If a [Character](Terminology#Character) performs a [Mitigated Attack](Terminolog
 #### Terminator
 You cannot be forced to move or knocked over.
 
-#### Trampler
-While [Mounted](Terminology#Mounted) when [Charging](Attack-Bonuses#Charging) #TODOMovement , you can cause an [Impact](Injury#Impact) [Ancillary](Injury#Ancillary) [Critical Injury](Injury#Critical%20Injury).
-
 
 ---
 
@@ -86,7 +83,10 @@ Your [Mounted Expert](#Mounted%20Expert) training applies to exotic forms of tra
 > Flight, Swimming, Teleporting, Scaling Walls, Burrowing
 
 #### Sweep
-As a [Melee Attack](Terminology#Melee%20Attack), you may make a [Strike](Strength#Strike) [[Skills#Fixed Difficulty]](0). If this is a [Non-mitigated Attack](Terminology#Non-mitigated%20Attack), all [Opponents](Terminology#Opponent) [In Melee](Terminology#In%20Melee) with you and within 3m #TODOMovement of you are knocked prone, they don't suffer [Injury](Injury).
+As a [Melee Attack](Terminology#Melee%20Attack), you may make a [Strike](Strength#Strike) [[Skills#Fixed Difficulty]](0). If this is a [Non-mitigated Attack](Terminology#Non-mitigated%20Attack), all [Opponents](Terminology#Opponent) within [Reach](Movement#Reach) of you are knocked [Prone](Effects#Prone), they don't suffer [Injury](Injury).
+
+#### Trampler
+While [Mounted](Terminology#Mounted) if you move within [Reach](Movement#Reach) of an [Opponent](Terminology#Opponent), you can perform a [Mannerism](Communication#Mannerism) [Fixed Difficulty](Skills#Fixed%20Difficulty)(0) to [Attack](Terminology#Attack) for an [Impact](Injury#Impact) [Ancillary](Injury#Ancillary) [Critical Injury](Injury#Critical%20Injury).
 
 ---
 

--- a/Game/Magic-Modifiers.md
+++ b/Game/Magic-Modifiers.md
@@ -43,12 +43,12 @@ Your [Attack](Terminology#Attack) does 1 additional [Damage](Terminology#Damage)
 This attack does not cause [Injury](Injury)
 
 ### Magic Attack
-*Action modifier (0)*
-This attacks adds [Spirit](Spirit) to damage bonus instead of [Strength](Strength) and has a [Range](Weapons#Range) of 10m. #TODOMovement
+*Mandatory*
+This attacks adds [Spirit](Spirit) to [Damage Bonus](Weapons#Damage%20Bonus) instead of [Strength](Strength) and has a [Range](Weapons#Range) of [Close](Movement#Close).
 
 ### Slowing
 *Action modifier (-1)*
-If this is a [Successful Attack](Terminology#Successful%20Attack) the [Opponent](Terminology#Opponent) cannot sprint or charge on their next turn. #TODOMovement 
+If this is a [Successful Attack](Terminology#Successful%20Attack) the [Opponent](Terminology#Opponent) is [Slowed](Effects#Slowed). 
 
 ### Stunning
 *Action modifier (-1)*

--- a/Game/Movement.md
+++ b/Game/Movement.md
@@ -1,0 +1,48 @@
+---
+layout: default
+title: Movement
+parent: Telling The Story
+nav_order: 0
+---
+## Movement
+In Aspirant, specifics of measurement, distance and the idea of "movement speed", are simplified. Instead of a movement speed, usually it is assumed your character can make it to where they want to go, the question is how rushed will you be when you get there.
+
+### Distance Increments
+Generally, when you are getting ready to do an action and plan to move towards something, there are 5 distances it can be from you:
+
+#### Reach
+The location is within reach.
+
+#### Close
+The location is nearby, basically anyone could make it there without too much trouble.
+
+#### Short
+The location is a short travel distance, it would be a challenge for most people to get there quickly. 
+
+#### Far
+The location is far off, even a very fast person would struggle to get to it quickly.
+
+#### Impossible
+The location isn't reachable in a timely manner. You should instead try to move towards it, but more narrative work needs to be done to get to it. 
+
+As a [GM](How-To-Play#GM) try to avoid making situations and locations where things are impossible to reach. Impossible should also include suggestions for more approachable milestones.
+
+#### Approximating Distance
+Distances shouldn't be set in stone, it should be flexible based on your characters' movement and the timescale of the current events. However, the following guidelines are provided.
+
+| Name       | Approximate Distance |
+| ---------- | -------------------- |
+| [Reach](#Reach)      | $< 3m$               |
+| [Close](#Close)      | $\approx 10m$        |
+| [Short](#Short)      | $\approx 20m$        |
+| [Far](#Far)        | $\approx 40m$        |
+| [Impossible](#Impossible) | $> 50m$              |
+
+### Movement Action Penalty
+When you are expected to travel to a location and immediately perform an action, like when in [Combat](Combat), or otherwise pressured, any action you take may be at a penalty based on your [Movement Distance](Stats#Movement%20Distance). 
+
+Your movement action penalty is equal to the number of additional distance increments you need to travel beyond your [Movement Distance](Stats#Movement%20Distance).
+
+> So if you had 2 [Agility](Agility) your [Movement Distance](Stats#Movement%20Distance) is [Reach](#Reach), if you were to move [Close](#Close) you would suffer a (-1) to an action, [Far](#Far) would be a (-3).
+
+There is no movement action penalty for [Impossible](#Impossible) because it isn't possible to arrive there. The character must spend some time in transit before making it, any action penalty would be based on their intermediate destination.

--- a/Game/Reacting-To-Attacks.md
+++ b/Game/Reacting-To-Attacks.md
@@ -17,7 +17,7 @@ The generally available reactions are:
 If an [Opponent](Terminology#Opponent) performs a [Successful Attack](Terminology#Successful%20Attack), you may perform a [Reflexes](Agility#Reflexes) [Fixed Difficulty](Skills#Fixed%20Difficulty)(-2). If you succeed, you ignore the effects of the attack unless otherwise specified.
 
 ### Move to Cover
-A [Grace](Agility#Grace) skill test where if you succeed then you may move to a piece of cover within agility meters #TODOMovement before an enemy ranged attack is calculated. You cannot Move to Cover while prone.
+A [Grace](Agility#Grace) skill test where if you succeed then you may move to a piece of cover within [Reach](Movement#Reach) before an enemy ranged attack is calculated. You cannot Move to Cover while [Prone](Effects#Prone).
 
 ### Attack of Opportunity
 If someone moves while [In Melee](Terminology#In%20Melee) with you, you may make an [Attack](Terminology#Attack) against them.

--- a/Game/Rogue.md
+++ b/Game/Rogue.md
@@ -45,7 +45,7 @@ You may [Disarm](Special-Combat-Actions#Disarm) using a [Reflexes](Agility#Refle
 You never trigger traps by moving over them. You also receive a +1 to [Grace](Agility#Grace) skill tests related to moving silently.
 
 #### Long Shot
-When making a [Ranged Attack](Terminology#Ranged%20Attack), you may spend a [Power](Stats#Power) to ignore any [Distance Penalty](Attack-Bonuses#Distance%20Penalty) #TODOMovement.
+When making a [Ranged Attack](Terminology#Ranged%20Attack), you may spend a [Power](Stats#Power) to ignore any [Distance Penalty](Attack-Bonuses#Distance%20Penalty).
 
 #### Lost in the Crowd
 If you are [In Melee](Terminology#In%20Melee) you have a [Threat](Stats#Threat) of 0 to [Characters](Terminology#Character) not [In Melee](Terminology#In%20Melee) with you.
@@ -54,7 +54,7 @@ If you are [In Melee](Terminology#In%20Melee) you have a [Threat](Stats#Threat) 
 On your [Combat Turn](Terminology#Combat%20Turn), you may make an [Attack](Terminology#Attack) at (-2) additional penalty, and then perform a non-attack action or movement.
 
 #### Olympian
-You can make a [Thrown Attack](Terminology#Thrown%20Attack) at the end of [Charging](Attack-Bonuses#Charging) #TODOMovement , receiving the bonuses. 
+Your [Thrown Attack](Terminology#Thrown%20Attack) count as having a range of 1 additional [Distance Increment](Movement#Distance%20Increments). 
 
 #### Pin Down
 After performing a [Ranged Attack](Terminology#Ranged%20Attack), the target must pass a [Identity](Spirit#Identity) [Fixed Difficulty(+0)](Skills#Fixed%20Difficulty) or be unable to move until your next [Combat Turn](Terminology#Combat%20Turn).
@@ -94,7 +94,7 @@ You can manoeuvre perfectly well in the dark or when your vision is otherwise im
 Your character's [Threat](Stats#Threat) is reduced by your ranks in [Grace](Agility#Grace).
 
 #### Vanish
-If within 3m #TODOMovement of something you could use to hide, as a [Free Action](Terminology#Free%20Action) you can spend 3 [Power](Stats#Power) to lose all attention. If you perform any [Action](Terminology#Action) you will need to continue to hide, move silently, etc. to remain hidden.
+If within [Reach](Movement#Reach) of something you could use to hide, as a [Free Action](Terminology#Free%20Action) you can spend 2 [Power](Stats#Power) to lose all attention. If you perform any [Action](Terminology#Action) you will need to continue to hide, move silently, etc. to remain hidden.
 
 
 ---

--- a/Game/Shaper.md
+++ b/Game/Shaper.md
@@ -36,7 +36,7 @@ You can set magical abilities you are focussed on to trigger in response to some
 When you perform a magical effect you can roll [Grace](Agility#Grace) [Opposed Difficulty](Skills#Opposed%20Difficulty)([Insight](Intelligence#Insight)) to make it seem like no magic took place.
 
 #### Mage Hand
-You can levitate things up to your [Spirit](Spirit) in size and [Spirit](Spirit) x 2 meters away #TODOMovement as naturally as picking them up normally.
+You can levitate things up to your [Spirit](Spirit) in size and [Close](Movement#Close) as naturally as picking them up normally.
 
 #### Shadow Illusionist
 As long as you have a focus, you can perform [Will](Spirit#Will) tests to sneak, move silently, hide and do other duplicitous acts.
@@ -50,7 +50,7 @@ You do not need to move your hands to perform [Channelled Magic](Magic#Channelle
 You can cast spells normally while transformed into a non-humanoid creature, even if you couldn't hold a [Focus](Example-Gear#Focus). You can also speak normally.
 
 #### Wire Fight
-You Can Use [Spirit](Spirit) instead of Agility to Calculate Movement distance. #TODOMovement 
+You Can Use [Spirit](Spirit) instead of [Agility](Agility) to Calculate [Movement Distance](Stats#Movement%20Distance). 
 
 ---
 
@@ -72,7 +72,7 @@ Your character can perform [Channelled Magic](Magic#Channelled%20Magic) to:
 
 #### Kinetic Monk
 *[Requirement](Terminology#Requirement): [Black Belt](Brawler#Black%20Belt)*
-While holding nothing but a [Focus](Example-Gear#Focus) you can [Substitute](Terminology#Substitute) [Will](Spirit#Will) for [Strike](Strength#Strike). While doing this, your [Melee Attacks](Terminology#Melee%20Attack) have a [Damage Bonus](Weapons#Damage%20Bonus) of $2 \times Spirit$ and you can attack at a range of $2 \times Spirit$ meters. #TODOMovement
+While holding nothing but a [Focus](Example-Gear#Focus) you can [Substitute](Terminology#Substitute) [Will](Spirit#Will) for [Strike](Strength#Strike). While doing this, your [Unarmed Attack](Terminology#Unarmed%20Attack) has a [Damage Bonus](Weapons#Damage%20Bonus) of $2 \times Spirit$ and a range of [Close](Movement#Close).
 
 #### Powerful Mind
 You can [Concentrate](Magic#Concentration) on two spells simultaneously.

--- a/Game/Special-Combat-Actions.md
+++ b/Game/Special-Combat-Actions.md
@@ -9,10 +9,10 @@ grand_parent: Telling The Story
 In combat there are several situations that come up often enough they should have predefined rules. This doesn't mean this list is exhaustive, but should give an idea of the sort of things you can do in combat apart from harming someone directly.
 
 ### Back out
-You make a [Grace](Agility#Grace) [Fixed Difficulty](Skills#Fixed%20Difficulty)(0) to step out of melee with an opponent. If you succeed, you can move agility * 2 meters and then perform an action at a -2 (as normal) #TODOMovement. If you fail, you provoke an attack of opportunity and then may do that anyway.
+You make a [Grace](Agility#Grace) [Fixed Difficulty](Skills#Fixed%20Difficulty)(0) to stop being [In Melee](Terminology#In%20Melee) with an opponent. If you succeed, you can [Move](Combat-Turn#Move) and then perform an action as normal, your [Opponent](Terminology#Opponent) can't make [Attack of Opportunity](Reacting-To-Attacks#Attack%20of%20Opportunity). If you fail, your opponent may [Attack of Opportunity](Reacting-To-Attacks#Attack%20of%20Opportunity) and then your [Combat-Turn](Combat-Turn) continues.
 
 ### Cautious Step
-You move out of melee with an enemy without provoking an attack of opportunity. You can move up to your agility * 2 meters #TODOMovement, but no other actions.
+You can only [Move](Combat-Turn#Move) on your [Combat-Turn](Combat-Turn), but [Opponent](Terminology#Opponent) cannot perform [Attack of Opportunity](Reacting-To-Attacks#Attack%20of%20Opportunity) against you.
 
 ### Disarm
 With at least one free hand or a melee weapon, you can attempt to disarm a [Character](Terminology#Character) [In Melee](Terminology#In%20Melee) with you. Make a [Strike](Strength#Strike) skill test at (-1) and if successful, your opponent drops their weapon (or it is now in your hands).

--- a/Game/Spirit.md
+++ b/Game/Spirit.md
@@ -7,7 +7,7 @@ grand_parent: How To Play
 ---
 ## Spirit
 
-Measures your spirit, your sense of self and the world around you. Influences your toxicity #TODO.
+Measures your spirit, your sense of self and the world around you. Influences your [Affinity](Stats#Affinity).
 
 It can be honed to better perform the [Skills](Skills):
 ### Attunement

--- a/Game/Star.md
+++ b/Game/Star.md
@@ -29,7 +29,7 @@ As [Skilled Work](Activities#Skilled%20Work), you can busk. Make a [Confidence](
 [Allies](Terminology#Ally) and yourself gain a (+1) to [Social Skill Test](Terminology#Social%20Action) when interacting with residents of an area.
 
 #### Decadent
-You never suffer penalties due to intoxication and your [Max Toxicity](Stats#Max%20Toxicity) is increased by 2.
+You never suffer penalties due to intoxication, you also recieve a (+2) to [Terminology](Terminology) actions related to resisting [Comestibles](Comestibles) downsides.
 
 #### Faithful
 You receive a +1 to all [Social Skill Test](Terminology#Social%20Action) against any [Opponent](Terminology#Opponent) who shares similar beliefs to your [Character](Terminology#Character).

--- a/Game/Star.md
+++ b/Game/Star.md
@@ -29,7 +29,7 @@ As [Skilled Work](Activities#Skilled%20Work), you can busk. Make a [Confidence](
 [Allies](Terminology#Ally) and yourself gain a (+1) to [Social Skill Test](Terminology#Social%20Action) when interacting with residents of an area.
 
 #### Decadent
-You never suffer penalties due to intoxication, you also recieve a (+2) to [Terminology](Terminology) actions related to resisting [Comestibles](Comestibles) downsides.
+You never suffer penalties due to intoxication, you also receive a (+2) to [Terminology](Terminology) actions related to resisting [Comestibles](Comestibles) downsides.
 
 #### Faithful
 You receive a +1 to all [Social Skill Test](Terminology#Social%20Action) against any [Opponent](Terminology#Opponent) who shares similar beliefs to your [Character](Terminology#Character).

--- a/Game/Star.md
+++ b/Game/Star.md
@@ -44,7 +44,7 @@ You can control an additional 2 [Followers](Terminology#Follower).
 After a successful [Strike](Strength#Strike), all your allies receive a +1 to all attack rolls until your next [Combat Turn](Terminology#Combat%20Turn).
 
 #### Lookout Sir
-If a [Follower](Terminology#Follower) #TODOFollowers under your control is within 3m #TODOMovement of you they may spend a [Reaction](Terminology#Reaction) to move to your character and become the target of the attack. They may still perform an [Avoid](Reacting-To-Attacks#Avoid).
+If a [Follower](Terminology#Follower) #TODOFollowers under your control is within [Reach](Movement#Reach) of you, they may spend a [Reaction](Terminology#Reaction) to move to your character and become the target of the attack. They may still perform an [Avoid](Reacting-To-Attacks#Avoid) [Reaction](Terminology#Reaction).
 
 #### Lover Not A Fighter
 You receive a (+1) to all [Actions](Terminology#Action) in situations where your life isn’t in danger, and you are not rushed. However, you receive a (-1) to all [Actions](Terminology#Action) while in combat.

--- a/Game/Stats.md
+++ b/Game/Stats.md
@@ -33,12 +33,22 @@ An abstraction of your characters' potential to learn and gain new abilities. [C
 Aspirants will not immediately spend experience as they gain it, expertise comes from the knowledge of others, so your spent XP should be tracked separately from your total.
 
 #### Power
-A stat tracking how many times you character can perform certain powerful abilities. Some [Training](Character-Development#Training) will require you to expend this resource. It can be regained using the [Good Night's Rest](Activities#Good%20Night's%20Rest) [Travel Activity](Activities#Travel%20Activity).
+A stat tracking how many times your character can perform certain powerful abilities. Some [Training](Character-Development#Training) will require you to expend this resource. It can be regained using the [Good Night's Rest](Activities#Good%20Night's%20Rest) [Travel Activity](Activities#Travel%20Activity).
 
-Power is equal to 2 + 1 per [Training](Character-Development#Training) that requires power.
+Power is equal to [Intelligence](Intelligence) + 1 per [Training](Character-Development#Training) that requires power.
 
-#### Move Speed
-How far your character can move in 1 turn of combat. [Agility](#Agility) * 4 meters.
+#### Movement Distance
+How far your character can comfortably move before suffering a penalty to actions when time is important. See [Movement](Movement) for more details.
+
+Movement Distance is based on your [Agility](Agility)
+
+| Agility | Distance                |
+| ------- | ----------------------- |
+| 1       | -                       |
+| 2       | [Reach](Movement#Reach) |
+| 3       | [Close](Movement#Close) |
+| 4       | [Short](Movement#Short) |
+| 5       | [Far](Movement#Far)     |
 
 #### Threat
 The size of your largest weapon. Used to determine who unintelligent monsters target at random. 
@@ -56,4 +66,4 @@ Toxicity resets to 0 during [Downtime](Telling-The-Story#Downtime).
 #### Influence
 A measure of the influence you as a player have over the story. See [Influencing the Story](Telling-The-Story#Influencing%20the%20Story) for more details.
 
-Starts at 0 and is rewarded for contributing to the game.
+You start with [Communication](Communication) influence, and can have a maximum influence equal to [Communication](Communication).

--- a/Game/Stats.md
+++ b/Game/Stats.md
@@ -56,12 +56,10 @@ The size of your largest weapon. Used to determine who unintelligent monsters ta
 * A character that is unarmed still has a base threat of 1. 
 * A character that is unconscious or otherwise detained should have a threat of 0.
 
-#### Max Toxicity
-Your characters can only handle a certain amount of foreign material in your body before becoming ill.
+#### Affinity
+The number of [Magic-Items](Magic-Items) you can use at any time.
 
-Characters have a Max Toxicity equal to their [Strength](Strength) + [Spirit](Spirit) attributes. Your max toxicity is reduced by 1 for any permanent enchantment, prosthetic with additional abilities, and mutation your character possesses. Whenever you imbibe an alchemical elixir or are positively affected by some form of magic your character marks a level of Toxicity when your characters Toxicity level is equal to or greater than your Max Toxicity you are considered injured.
-
-Toxicity resets to 0 during [Downtime](Telling-The-Story#Downtime).
+Affinity is equal to your [Spirit](Spirit).
 
 #### Influence
 A measure of the influence you as a player have over the story. See [Influencing the Story](Telling-The-Story#Influencing%20the%20Story) for more details.

--- a/Game/Storage.md
+++ b/Game/Storage.md
@@ -12,7 +12,7 @@ Your character in general will have 20 size worth of storage on their character 
 Items readily available to your character. Belted items can be drawn/stowed for free, but will put any actions in a combat turn at a -1. Default storage for a belt is 4 size of items.
 
 ### Backpack
-Items stowed for longer storage using the support of your core. Bag items can be drawn/stowed as an action in combat. Default storage for a backpack is 6 size of items.
+Items stowed for longer storage using the support of your core. Bag items can be drawn/stowed as an action in combat. Default storage for a backpack is 4 + [Strength](Strength) size of items.
 
 ### Saddlebag
 Storage bags using the strength of your horse. If you are with your horse, it will take a combat action to retrieve or stow to saddle bags. Default storage for saddlebags is 10 size of items.

--- a/Game/Strength.md
+++ b/Game/Strength.md
@@ -7,7 +7,7 @@ grand_parent: How To Play
 ---
 ## Strength
 
-Measures how strong your character is. Influences [Max Toxicity](Stats#Max%20Toxicity) and melee weapon damage.
+Measures how strong your character is. Influences [Backpack](Storage#Backpack) carry weight.
 
 It can be honed to better perform the [Skills](Skills):
 ### Athletics

--- a/Game/Terminology.md
+++ b/Game/Terminology.md
@@ -35,7 +35,7 @@ In combat, a combat round is all the actions of every [Character](#Character) in
 In combat, a turn is a [Character's](#Character) portion of the round. What they are doing is happening in parallel with everyone else, but for simplicity the game takes things in an order determined by [Initiative Value](Combat#Initiative%20Value). On a character's turn, they can usually do one action and potentially move. See [Combat-Turn](Combat-Turn) for more details on what a character can do.
 
 ### Opponent
-The opposition of a skill test. The character who will be negatively effected by the outcome.
+The opposition of a currently referenced [Character](#Character). The character who will be negatively effected by your actions, or you would be by theirs.
 
 ### In Melee
 A character is considered in melee if they are actively fighting another character with a weapon that does not have a specified range. Generally, this means they are within 2 meters of an [Opponent](#Opponent) and the [Character](#Character) has either attacked or been attacked. See [Being in Melee Combat](Combat#Being%20in%20Melee%20Combat) for more details.
@@ -44,7 +44,7 @@ A character is considered in melee if they are actively fighting another charact
 References a player character, NPC, creature, or other entity that might perform an action, or have an action performed on them.
 
 ### Melee Attack
-An [Attack](#Attack) with a weapon with no otherwise specified range that is not thrown. You can generally make a melee attack within 2m of your opponent.
+An [Attack](#Attack) with a weapon with no otherwise specified range that is not thrown. You can generally make a melee attack within [Reach](Movement#Reach).
 
 ### Thrown Attack
 An [Attack](#Attack) with a weapon which is thrown at the target. Things like bows and crossbows are not thrown attacks.
@@ -107,7 +107,20 @@ Refers to a bonus being able to be taken multiple times to get the effect repeat
 ### Charges
 An abstracted count of the number of times an item can be used. If charges are written as X(Y), then the item has X charges and charges can be refreshed for Y silver.
 
-> Example: a tool kit has 3(2) charges, means it can be used 3 times and can have it's uses refreshed for 2 silver each.
+> Example: a tool kit has 3(2) charges, means it can be used 3 times and can have its uses refreshed for 2 silver each.
 
 ### Difficulty Value
 The penalty for an [Action](#Action) assigned by the [GM](How-To-Play#GM).
+
+### Unarmed Attack
+An unarmed attack is a [Melee Attack](#Melee%20Attack) without a weapon, using only your limbs. It causes [Minimal Injury](Injury#Minimal%20Injury) [Impact](Injury#Impact).
+
+### Loading
+Some weapons and equipment will require a certain amount of time to be ready for use. This is the loading time. Loading time is specified as (X) where X is the number of round, or 0 for [Free Action](#Free%20Action).
+
+If something can be loaded as a free action, immediately using it puts the action at a (-1).
+
+### Capacity
+The number and type of things that this item can be [Loaded](#Loading) with. Usually written as Capacity X(Y), which means it holds X ammo, and is loaded with Y item.
+
+> So a weapon described as having Capacity 12([Munitions](Comestibles#Munitions)) would hold 12 generic ammo.

--- a/Game/Wanderer.md
+++ b/Game/Wanderer.md
@@ -75,7 +75,7 @@ After [Injuring](Injury) someone, if they would die, you may opt for them to go 
 If characters hostile to you, are not aware of you at the start of combat, you get a [Combat Turn](Terminology#Combat%20Turn) before the first [Combat Round](Terminology#Combat%20Round).
 
 #### Cram Session
-During [Meditate](Activities#Meditate), you can select any one of your skills that isn’t already at 3 ranks to count as being one rank higher until the next meditation.
+During [Good Night's Rest](Activities#Good%20Night's%20Rest), you can select any one of your skills that isn’t already at 3 ranks to count as being one rank higher until the next meditation.
 
 #### Field Dressing
 When collecting bits from creatures after an encounter, you may collect one additional from any monster you choose.

--- a/Game/Weapon-Traits.md
+++ b/Game/Weapon-Traits.md
@@ -6,32 +6,28 @@ grand_parent: Equipment
 nav_order: 2
 ---
 ## [Weapon](Weapons) Traits
+{: .no_toc }
 
-| Name                                                | Cost |
-| --------------------------------------------------- | ---- |
-| [Balanced](#Balanced)                               | 1    |
-| [Black Powder](#Black%20Powder)                     | 1    |
-| [Crossbow](#Crossbow)                               | 1    |
-| [Deadly Draw](#Deadly%20Draw)                       | 1    |
-| [Disguised](#Disguised)                             | 1    | 
-| [Ensnaring](#Ensnaring)                             | 1    |
-| [Fast Reloading](#Fast%20Reloading)                 | 1    |
-| [Hand and a Half](#Hand%20and%20a%20Half)           | 1    |
-| [Inscribed](#Inscribed)                             | 1    |
-| [Lethal](#Lethal)                                   | 1    |
-| [Momentum](#Momentum)                               | 1    |
-| [Multiple Damage Types](#Multiple%20Damage%20Types) | 1    |
-| [Multiple Shots](#Multiple%20Shots)                 | 1    |
-| [On Line](#On%20Line)                               | 1    |
-| [Reach](#Reach)                                     | 1    |
-| [Shield](#Shield)                                   | 1    |
-| [Sling](#Sling)                                     | 1    |
-| [Throwable](#Throwable)                             | 1    |
-| [Bow](#Bow)                                         | 2    |
-| [Folding](#Folding)                                 | 2    |
-| [Overweight](#Overweight)                           | 2    |
-| [Penetrating](#Penetrating)                         | 2    |
-| [Perfect](#Perfect)                                 | 2    |
+### Contents
+{: .no_toc }
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+### Special Traits
+These are weapon traits that can't be selected, either being [Default Traits](Designing-Weapons#Default%20Traits), or obtained some other way.
+#### Strength
+This weapon adds [Strength](Strength) to [Damage Bonus](Weapons#Damage%20Bonus).
+
+#### Size Matters
+This weapon adds $size \times 2$ to [Damage Bonus](Weapons#Damage%20Bonus).
+
+
 
 ### 1 Cost Traits
 
@@ -39,16 +35,31 @@ nav_order: 2
 +1 to defensive skill tests using this weapon.
 
 #### Black Powder
-Your weapon fires balls of lead propelled by incendiary powder. It no longer can be used as a melee weapon and is instead a ranged weapon with a range equal to 10m x size. You don’t add your [Strength](Strength) to damage, but get an inherent +6 damage bonus. Reloading a black powder weapon takes 1 minute. 
+*Your weapon fires balls of lead propelled by incendiary powder.*
+* Loses the [Strength](#Strength) trait.
+* +6 [Damage Bonus](Weapons#Damage%20Bonus). 
+* [Loading](Terminology#Loading)(2).
+* Range of [Far](Movement#Far).
+* [Capacity](Terminology#Capacity) 1([Munitions](Comestibles#Munitions)).
 
 #### Bow
-This weapon fires arrows. It no longer can be used as a melee weapon and is instead a ranged weapon with a range equal to 10m x size. You can add [Strength](Strength) to damage up to a maximum of the size of the weapon. Readying an arrow and firing a bow in the same turn gives a -1 to the [Accuracy](Agility#Accuracy) test.
+*This weapon fires arrows.* 
+* Loses the [Strength](#Strength) trait.
+* You can add [Strength](Strength) to damage *only* up to a maximum of the size of the weapon. 
+* [Loading](Terminology#Loading)(0).
+* Range of [Short](Movement#Short).
+* [Capacity](Terminology#Capacity) 1([Munitions](Comestibles#Munitions)).
 
 #### Crossbow
-Your weapon fires bolts of metal. It no longer can be used as a melee weapon and is instead a ranged weapon with a range equal to 10m x size #TODOMovement. You don’t add your [Strength](Strength) to damage, but add an additional size to [Damage Bonus](Weapons#Damage%20Bonus) (3x total). After firing a crossbow, it takes a combat turn to reload.
+*Your weapon fires bolts of metal.*
+* Loses the [Strength](#Strength) trait.
+* Add size to [Damage Bonus](Weapons#Damage%20Bonus) (in addition to [Size Matters](#Size%20Matters)).
+* [Loading](Terminology#Loading)(1).
+* Range of [Short](Movement#Short).
+* [Capacity](Terminology#Capacity) 1([Munitions](Comestibles#Munitions)).
 
 #### Deadly Draw
-This weapon is penetrative for your first attack in any combat.
+This weapon is [Penetrating](#Penetrating) for your first attack in any combat.
 
 #### Disguised
 This does not appear to be a weapon but has -1 [Damage Bonus](Weapons#Damage%20Bonus).
@@ -57,10 +68,10 @@ This does not appear to be a weapon but has -1 [Damage Bonus](Weapons#Damage%20B
 This weapon deals -2 damage, on [Non-mitigated Attack](Terminology#Non-mitigated%20Attack) it causes the enemy to be [Grappled](Special-Combat-Actions#grapple). You need to maintain hold of the ensnaring weapon to maintain the [Grapple](Special-Combat-Actions#grapple).
 
 #### Fast Reloading
-If your weapon requires ammo, it can be reloaded in half the time. Reloads that normally take an action are instead free, and any skill tests performed that turn are at a -2.
+If your weapon requires [Loading](Terminology#Loading), it takes half the time. [Loading](Terminology#Loading) that normally takes an action is instead a [Free Action](Terminology#Free%20Action).
 
 #### Hand and a Half
-If this weapon is otherwise usable in one hand, the weapon counts as 1 size larger while wielded in two hands. The weapon receives one additional trait that only applies when used in two hands.
+If this weapon is otherwise usable in one hand, the weapon counts as 1 size larger while wielded in two hands.
 
 #### Inscribed
 This weapon counts as a Focus for [Will](Spirit#Will) skill tests.    
@@ -72,22 +83,25 @@ This weapon has 1 additional [Damage Bonus](Weapons#Damage%20Bonus).
 Whenever you attack with this weapon and don’t strike anything (either miss or the attack is dodged) your next [Attack](Terminology#Attack) gains (+1), this stacks. 
 
 #### Multiple Damage Types
-When you create this weapon, choose two [Damage Type](Weapons#Damage%20Type) instead of one. When you attack, select one of the two types.       
+This weapon has an additional combat profile with the default traits and a different [Types of Damage](Injury#Types%20of%20Damage). When you attack, select one of the two types.       
 
 #### Multiple Shots
-If your weapon requires ammo, it can hold 3 additional readied shots.   
+If your weapon has [Capacity](Terminology#Capacity) it has 3 additional.   
 
 #### On Line
-This weapon cannot be used to perform [Reactions](Terminology#Reaction), you can make melee skill tests with this weapon at a range of 6m.
+This weapon cannot be used to perform [Reactions](Terminology#Reaction), you can make [Melee Attack](Terminology#Melee%20Attack) with this weapon at a range of [Close](Movement#Close), you cannot attack further taking a [Distance Penalty](Attack-Bonuses#Distance%20Penalty).
 
 #### Reach
-A weapon with the reach trait can be used to perform melee attacks up to 2m away, and doing so doesn’t put you in melee combat with the target.
+Performing [Melee Attack](Terminology#Melee%20Attack) doesn't put you [In Melee](Terminology#In%20Melee). You contribute to [Outnumbered](Attack-Bonuses#Outnumbered) for anyone in [Reach](Movement#Reach).
 
 #### Shield
-This weapon can no longer be used for attacks. Instead, it provides a +2 to defensive skill tests using it. #TODO
+This weapon can no longer be used for attacks. Instead, it provides a +2 to skill tests using it. #TODO
 
 #### Sling
-This weapon aids with throwing things long distances. A size 1 or 2 sling doubles your thrown range, size 3 or 4 triples it, and a size 5 sling quadruples your thrown range. If you load and launch a sling in the same turn, your skill test to attack is at a -1.
+*This weapon aids with throwing things long distances.*
+* [Loading](Terminology#Loading)(0).
+* [Capacity](Terminology#Capacity) 1([Throwable](#Throwable) weapons).
+* While using this weapon you perform throws as normal, however you count as having a range of 1 additional [Distance Increment](Movement#Distance%20Increments). 
 
 #### Throwable
 This weapon is balanced for throwing, you receive no penalties for throwing it.  
@@ -96,13 +110,13 @@ This weapon is balanced for throwing, you receive no penalties for throwing it.
 ### 2 Cost Traits
 
 #### Folding
-This weapon counts as two separate sizes. When stored, it is considered the smaller size. As an action, you may change which size it counts as, or at the end of any attack action you can change the size. Aside from folding the weapon can count as having separate traits in each form.
+This weapon counts as two separate sizes. When stored, it is considered the smaller size. As an action, you may change which size it counts as, or at the end of any attack action you can change the size. Aside from folding the weapon can count as having a single separate [1 Cost Traits](#1%20Cost%20Traits) in each form.
 
 #### Overweight
 This weapon has (-1) to [Actions](Terminology#Action) made with it and +3 [Damage Bonus](Weapons#Damage%20Bonus). 
 
 #### Penetrating
-This weapon ignores resistances of armour.
+This weapon ignores [Resistance](Armour#Weakness%20and%20Resistance) of armour.
 
 #### Perfect
 This weapon receives a (+1) to [Actions](Terminology#Action) made with it, and a +1 to [Damage Bonus](Weapons#Damage%20Bonus).

--- a/Game/Weapons.md
+++ b/Game/Weapons.md
@@ -11,7 +11,7 @@ Weapon [Equipment](Equipment) can normally be separated into 3 categories: Basic
 In the world of Aspirant, there are plenty of unique weapons to be found and experienced. Some examples will be provided, along with rules for creating your own weapons in each category.
 
 ### Damage Bonus
-Weapons have a damage bonus, used to calculate how much [Damage](Terminology#Damage) they do. See [Calculating Damage](Attacks#Calculating%20Damage). A weapon, if not otherwise specified, should add a [Character](Terminology#Character) [Strength](Strength) to damage bonus.
+Weapons have a damage bonus, used to calculate how much [Damage](Terminology#Damage) they do. See [Calculating Damage](Attacks#Calculating%20Damage).
 
 ### Size
 Weapons, like all items, come in various sizes. However, in the case of weapons, an item's size has more effect than just the required storage space. 
@@ -33,7 +33,7 @@ Size 5 - Giant Weapons
 Weapons can usually have any of the physical damage types [Piercing](Injury#Piercing), [Rending](Injury#Rending), [Impact](Injury#Impact). This will affect what injuries it will cause and what armour will defend against it. Fabrics tend to be strong against [Impact](Injury#Impact), plates against [Rending](Injury#Rending), and weaves against [Piercing](Injury#Piercing). 
 
 ### Range
-Weapons, unless specified, can only be used in melee. Most characters can attack anything within 2m in melee. Some traits will modify range, though. #TODOMovement 
+Weapons, unless specified, can only be used to attack things in [Reach](Movement#Reach). Some traits may give a weapon a specific range however.
 
 ### [Weapon-Traits](Weapon-Traits)
 Abilities or unique effects a weapon might possess. If you have an idea in mind as a player or game master, try to come up with a unique trait to properly represent a weapon.  Traits can either count as 1 or 2 traits towards a weapon's total, depending on how powerful the trait is. A non-exhaustive list is provided [here](Weapon-Traits). 


### PR DESCRIPTION
Changed around the bonuses that Stats provide (outside skills):
* Strength gives backpack carry weight
* Agility gives movement distance
* Intelligence gives power
* Communication gives influence cap
* Spirit gives number of magic items you can use

As well, I've overhauled movement to benefit theatre of the mind, the book *should* no longer specify movement distances.